### PR TITLE
Fix: 이메일 회원가입 안되면 이슈 해결 fixed - #1 #5

### DIFF
--- a/feature/email-signup/email-signup.txt
+++ b/feature/email-signup/email-signup.txt
@@ -1,2 +1,4 @@
 # this is feature for email-signup
 email-signup
+
+email bug fix


### PR DESCRIPTION
원인 : 철자 에러로 인한 에러

조치내용 : 해당 철자 수정

결과 : 정상적으로 이메일 회원 가입 진행 되는 것 확인